### PR TITLE
Use sendto rather than connect for transmission

### DIFF
--- a/mefamo/mefamo.py
+++ b/mefamo/mefamo.py
@@ -160,11 +160,10 @@ class Mefamo():
 
     def _network_loop(self):
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:            
-            s.connect((self.ip, self.upd_port))
             while True: 
                 with self.lock:
                     if self.got_new_data:                               
-                        s.sendall(self.network_data)
+                        s.sendto(self.network_data, (self.ip, self.upd_port))
                         self.got_new_data = False
                 time.sleep(0.01)
 


### PR DESCRIPTION
At least on Linux, presently the software's network thread will throw an error if the server hasn't been setup yet
this also prevents inspection via, say, Wireshark without first setting up a dummy server via, say, `nc -u -l 127.0.0.1 11111 | hexdump -C`
